### PR TITLE
Update dangling references to cloudfoundry-incubator.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You have to deploy and run your own operator. Currently SF-Inter-Operator suppor
 #### Deploy using publicly published helm chart (Recommended)
 To add service fabrik interoperator helm chart repo
 ```shell
-helm repo add interoperator-charts https://cloudfoundry-incubator.github.io/service-fabrik-broker/helm-charts
+helm repo add interoperator-charts https://cloudfoundry.github.io/service-fabrik-broker/helm-charts
 helm repo update
 ```
 

--- a/broker/config/settings.yml
+++ b/broker/config/settings.yml
@@ -1012,7 +1012,7 @@ defaults: &defaults
           template: <%= base64_template('templates/rabbitmq-manifest.yml.ejs') %>
           releases: &dedicated_releases
           - { name: rabbitmq, version: 25 }
-          # An agent running in the deployment should implement Service Fabrik Agent APIs listed here https://cloudfoundry-incubator.github.io/service-fabrik-broker/api/agent_v1.1.html
+          # An agent running in the deployment should implement Service Fabrik Agent APIs listed here https://cloudfoundry.github.io/service-fabrik-broker/api/agent_v1.1.html
           - { name: broker-agent-rabbitmq, version: 36 }
           context: &context_plan9
             agent: *agent_rabbitmq
@@ -1057,7 +1057,7 @@ defaults: &defaults
           template: <%= base64_template('templates/rabbitmq-manifest.yml.ejs') %>
           releases: &dedicated_releases
           - { name: rabbitmq, version: 25 }
-          # An agent running in the deployment should implement Service Fabrik Agent APIs listed here https://cloudfoundry-incubator.github.io/service-fabrik-broker/api/agent_v1.1.html
+          # An agent running in the deployment should implement Service Fabrik Agent APIs listed here https://cloudfoundry.github.io/service-fabrik-broker/api/agent_v1.1.html
           - { name: broker-agent-rabbitmq, version: 36 }
           context: &context_plan9
             agent: *agent_rabbitmq
@@ -1195,7 +1195,7 @@ defaults: &defaults
           template: <%= base64_template('templates/postgresql-manifest.yml.ejs') %>
           releases: &dedicated_releases
           - { name: postgresql, version: 121 }
-          # An agent running in the deployment should implement Service Fabrik Agent APIs listed here https://cloudfoundry-incubator.github.io/service-fabrik-broker/api/agent_v1.1.html
+          # An agent running in the deployment should implement Service Fabrik Agent APIs listed here https://cloudfoundry.github.io/service-fabrik-broker/api/agent_v1.1.html
           - { name: broker-agent-postgresql, version: 83 }
           context: &context_plan11
             agent: *agent_postgresql

--- a/docs/interoperator-upgrades.md
+++ b/docs/interoperator-upgrades.md
@@ -77,7 +77,7 @@ kubectl -n interoperator delete statefulset provisioner --ignore-not-found
 
 To add service fabrik interoperator helm chart repo if not already added
 ```shell
-helm repo add interoperator-charts https://cloudfoundry-incubator.github.io/service-fabrik-broker/helm-charts
+helm repo add interoperator-charts https://cloudfoundry.github.io/service-fabrik-broker/helm-charts
 helm repo update
 ```
 
@@ -98,7 +98,7 @@ Once the ClusterRole is deleted the existing deployment stops working and there 
 
 To add service fabrik interoperator helm chart repo if not already added
 ```shell
-helm repo add interoperator-charts https://cloudfoundry-incubator.github.io/service-fabrik-broker/helm-charts
+helm repo add interoperator-charts https://cloudfoundry.github.io/service-fabrik-broker/helm-charts
 helm repo update
 ```
 


### PR DESCRIPTION
Following move of repo from https://github.com/cloudfoundry-incubator/service-fabrik-broker/ to https://github.com/cloudfoundry/service-fabrik-broker/