### PR TITLE
Add the planId to the labels of the plan CRD

### DIFF
--- a/broker/data-access-layer/eventmesh/src/utils/index.js
+++ b/broker/data-access-layer/eventmesh/src/utils/index.js
@@ -119,7 +119,8 @@ function getPlanCrdFromConfig(plan, service) {
       name: plan.id,
       labels: {
         'controller-tools.k8s.io': '1.0',
-        serviceId: service.id
+        serviceId: service.id,
+        planId: plan.id
       }
     },
     spec: {


### PR DESCRIPTION
The plan id label is added and used by the interoperator, but it should also be initially applied when writing the CRDs into the cluster as it is done with the serviceId label.

This PR supersedes #1334 