### PR TITLE
[IOP] Logging parameters are made configurable

### DIFF
--- a/broker/core/logging/src/index.js
+++ b/broker/core/logging/src/index.js
@@ -42,7 +42,7 @@ const transports = [
     )
   }),
   new winston.transports.Console({
-    level: process.env.LOG_LEVEL || 'debug',
+    level: process.env.LOG_LEVEL || config.log_level || 'debug',
     silent: _.includes(['production', 'test'], process.env.NODE_ENV),
     format: winston.format.combine(
       winston.format.prettyPrint(),

--- a/docs/Interoperator.md
+++ b/docs/Interoperator.md
@@ -994,7 +994,7 @@ behavior:
 
 ### Interoperator
 
-In interoperator we are using `zap` (i.e. sigs.k8s.io/controller-runtime/pkg/log/zap ) plugin for logging. The log level, stacktrace level and output format can be changed/configured from values.yal file.  
+In interoperator we are using `zap` (i.e. sigs.k8s.io/controller-runtime/pkg/log/zap) plugin for logging. The log level, stacktrace level and output format can be changed/configured from [values.yaml](../helm-charts/interoperator/values.yaml).
 * values.interoperator.log_level : To set log level. Allowed values are 'info', 'error', 'debug' or any integer value > 0 (i.e. 1 or 2 or 3). Default value is 'info'.  
 * values.interoperator.log_output_format : Log Output format or Encoder. Allowed values are 'json' or 'console'. Default value is 'json'.  
 * values.interoperator.log_stacktrace_level : Allowed values are 'info', 'error' or 'panic'. Default value is 'error'.   

--- a/docs/Interoperator.md
+++ b/docs/Interoperator.md
@@ -995,11 +995,11 @@ behavior:
 ### Interoperator
 
 In interoperator we are using `zap` (i.e. sigs.k8s.io/controller-runtime/pkg/log/zap) plugin for logging. The log level, stacktrace level and output format can be changed/configured from [values.yaml](../helm-charts/interoperator/values.yaml).
-* values.interoperator.log_level : To set log level. Allowed values are 'info', 'error', 'debug' or any integer value > 0 (i.e. 1 or 2 or 3). Default value is 'info'.  
-* values.interoperator.log_output_format : Log Output format or Encoder. Allowed values are 'json' or 'console'. Default value is 'json'.  
-* values.interoperator.log_stacktrace_level : Allowed values are 'info', 'error' or 'panic'. Default value is 'error'.   
+* interoperator.log_level: To set log level. Allowed values are `info`, `error`, `debug` or any integer value > 0 (i.e. 1 or 2 or 3). Default value is `info`.  
+* interoperator.log_output_format: Log Output format or Encoder. Allowed values are `json` or `console`. Default value is `json`.  
+* interoperator.log_stacktrace_level: Allowed values are `info`, `error` or `panic`. Default value is `error`.   
 
 ### Broker  
 
 For Broker we can change log level from values.yaml file.  
-* values.broker.log_level: Allowed values are 'info', 'error' or 'debug'. Default value is info.   
+* broker.log_level: Allowed values are `info`, `error` or `debug`. Default value is `info`. 

--- a/docs/Interoperator.md
+++ b/docs/Interoperator.md
@@ -76,6 +76,7 @@ Architects, Developers, Product Owners, Development Managers who are interested 
   - [Default behavior for interoperator HPA](#default-behavior-for-interoperator-hpa)
   - [Scaling Policies](#scaling-policies)
   - [Stabilization Window](#stabilization-window)
+- [Logging](#logging)
 
 
 ## Context
@@ -988,3 +989,17 @@ behavior:
       value: 30
       periodSeconds: 30
 ```
+
+## Logging  
+
+### Interoperator
+
+In interoperator we are using `zap` (i.e. sigs.k8s.io/controller-runtime/pkg/log/zap ) plugin for logging. The log level, stacktrace level and output format can be changed/configured from values.yal file.  
+* values.interoperator.log_level : To set log level. Allowed values are 'info', 'error', 'debug' or any integer value > 0 (i.e. 1 or 2 or 3). Default value is 'info'.  
+* values.interoperator.log_output_format : Log Output format or Encoder. Allowed values are 'json' or 'console'. Default value is 'json'.  
+* values.interoperator.log_stacktrace_level : Allowed values are 'info', 'error' or 'panic'. Default value is 'error'.   
+
+### Broker  
+
+For Broker we can change log level from values.yaml file.  
+* values.broker.log_level: Allowed values are 'info', 'error' or 'debug'. Default value is info.   

--- a/docs/operator_apis.md
+++ b/docs/operator_apis.md
@@ -233,7 +233,7 @@ Triggering update for 5 instances
 
 ## Logging  
 
-In operator-apis we are using `zap` (i.e. sigs.k8s.io/controller-runtime/pkg/log/zap ) plugin for logging. The log level, stacktrace level and output format can be changed/configured from values.yal file.  
+In operator-apis we are using `zap` (i.e. sigs.k8s.io/controller-runtime/pkg/log/zap) plugin for logging. The log level, stacktrace level and output format can be changed/configured from [values.yaml](helm-charts/interoperator/values.yaml).
 * values.operator_apis.log_level : To set log level. Allowed values are 'info', 'error', 'debug' or any integer value > 0 (i.e. 1 or 2 or 3).  
 * values.operator_apis.log_output_format : Log Output format or Encoder. Allowed values are 'json' or 'console'.  
 * values.operator_apis.log_stacktrace_level : Allowed values are 'info', 'error' or 'panic'.  

--- a/docs/operator_apis.md
+++ b/docs/operator_apis.md
@@ -230,3 +230,10 @@ Response Code: 200
 Response Body:
 Triggering update for 5 instances
 ```
+
+## Logging  
+
+In operator-apis we are using `zap` (i.e. sigs.k8s.io/controller-runtime/pkg/log/zap ) plugin for logging. The log level, stacktrace level and output format can be changed/configured from values.yal file.  
+* values.operator_apis.log_level : To set log level. Allowed values are 'info', 'error', 'debug' or any integer value > 0 (i.e. 1 or 2 or 3).  
+* values.operator_apis.log_output_format : Log Output format or Encoder. Allowed values are 'json' or 'console'.  
+* values.operator_apis.log_stacktrace_level : Allowed values are 'info', 'error' or 'panic'.  

--- a/docs/operator_apis.md
+++ b/docs/operator_apis.md
@@ -233,7 +233,7 @@ Triggering update for 5 instances
 
 ## Logging  
 
-In operator-apis we are using `zap` (i.e. sigs.k8s.io/controller-runtime/pkg/log/zap) plugin for logging. The log level, stacktrace level and output format can be changed/configured from [values.yaml](helm-charts/interoperator/values.yaml).
+In operator-apis we are using `zap` (i.e. sigs.k8s.io/controller-runtime/pkg/log/zap) plugin for logging. The log level, stacktrace level and output format can be changed/configured from [values.yaml](../helm-charts/interoperator/values.yaml).
 * values.operator_apis.log_level : To set log level. Allowed values are 'info', 'error', 'debug' or any integer value > 0 (i.e. 1 or 2 or 3).  
 * values.operator_apis.log_output_format : Log Output format or Encoder. Allowed values are 'json' or 'console'.  
 * values.operator_apis.log_stacktrace_level : Allowed values are 'info', 'error' or 'panic'.  

--- a/helm-charts/interoperator/conf/settings.yaml
+++ b/helm-charts/interoperator/conf/settings.yaml
@@ -120,4 +120,4 @@ development: &development
 
 kubernetes:
   <<: *development
-  log_level: debug
+  log_level: {{ .Values.broker.log_level }}

--- a/helm-charts/interoperator/templates/multiclusterdeployer.yaml
+++ b/helm-charts/interoperator/templates/multiclusterdeployer.yaml
@@ -45,6 +45,9 @@ spec:
         args:
         - --metrics-addr=:8443
         - --enable-leader-election
+        - --zap-log-level={{ .Values.interoperator.log_level }}
+        - --zap-encoder={{ .Values.interoperator.log_output_format }}
+        - --zap-stacktrace-level={{ .Values.interoperator.log_stacktrace_level }}
         {{- $resourceSpec := dict }}
         {{- with .Values.interoperator.multiclusterdeployer.resources }}
           {{- $resourceSpec = deepCopy . }}

--- a/helm-charts/interoperator/templates/operator_api_app.yaml
+++ b/helm-charts/interoperator/templates/operator_api_app.yaml
@@ -126,5 +126,9 @@ spec:
         {{- if not (empty $resourceSpec) }}
         {{- tpl (.Files.Get "conf/resources.yaml") (merge $resourceSpec .) | nindent 8 }}
         {{- end }}
+        args:
+        - --zap-log-level={{ .Values.interoperator.log_level }}
+        - --zap-encoder={{ .Values.interoperator.log_output_format }}
+        - --zap-stacktrace-level={{ .Values.interoperator.log_stacktrace_level }}
       restartPolicy: Always
 {{- end }}

--- a/helm-charts/interoperator/templates/provisioner.yaml
+++ b/helm-charts/interoperator/templates/provisioner.yaml
@@ -39,6 +39,9 @@ spec:
         args:
         - --metrics-addr=:8443
         - --enable-leader-election
+        - --zap-log-level={{ .Values.interoperator.log_level }}
+        - --zap-encoder={{ .Values.interoperator.log_output_format }}
+        - --zap-stacktrace-level={{ .Values.interoperator.log_stacktrace_level }}
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/helm-charts/interoperator/templates/scheduler.yaml
+++ b/helm-charts/interoperator/templates/scheduler.yaml
@@ -43,6 +43,9 @@ spec:
         args:
         - --metrics-addr=:8443
         - --enable-leader-election
+        - --zap-log-level={{ .Values.interoperator.log_level }}
+        - --zap-encoder={{ .Values.interoperator.log_output_format }}
+        - --zap-stacktrace-level={{ .Values.interoperator.log_stacktrace_level }}
         {{- $resourceSpec := dict }}
         {{- with .Values.interoperator.scheduler.resources }}
           {{- $resourceSpec = deepCopy . }}

--- a/helm-charts/interoperator/values.yaml
+++ b/helm-charts/interoperator/values.yaml
@@ -191,6 +191,13 @@ interoperator:
       requests:
         cpu: 400m
         memory: 64Mi
+  
+  #Define log level. Can be one of 'debug', 'info', 'error', or any integer value > 0 (i.e. 1 or 2 or 3)
+  log_level: info
+  # Log Output format or Encoder (one of 'json' or 'console')
+  log_output_format: json
+  # Log stack strace level can have any value from list 'info' or 'error' or 'panic'
+  log_stacktrace_level: error
 
 operator_apis:
   enabled: true

--- a/helm-charts/interoperator/values.yaml
+++ b/helm-charts/interoperator/values.yaml
@@ -224,6 +224,12 @@ operator_apis:
   ssl: true
   sslsecret: op-api-ssl-cert
 
+  #Define log level. Can be one of 'debug', 'info', 'error', or any integer value > 0 (i.e. 1 or 2 or 3)
+  log_level: info
+  # Log Output format or Encoder (one of 'json' or 'console')
+  log_output_format: json
+  # Log stack strace level can have any value from list 'info' or 'error' or 'panic'
+  log_stacktrace_level: error
 
 #imagePullSecrets:
 #- name: docker-dmz

--- a/helm-charts/interoperator/values.yaml
+++ b/helm-charts/interoperator/values.yaml
@@ -13,6 +13,7 @@ broker:
   port: 9293
   username: broker
   password: secret
+  log_level: info
   enable_namespaced_separation: true
   services_namespace: "services"
   allow_concurrent_operations: true

--- a/interoperator/main.go
+++ b/interoperator/main.go
@@ -56,9 +56,11 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-addr", ":9877", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", true,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	opts := zap.Options{}
+	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	leaderElectionNamespace := constants.InteroperatorNamespace
 
@@ -71,6 +73,7 @@ func main() {
 		Port:                    9443,
 		SyncPeriod:              &syncPeriod,
 	})
+
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/operator-apis/main.go
+++ b/operator-apis/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -15,7 +16,11 @@ import (
 )
 
 func main() {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	opts := zap.Options{}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	setupLog := ctrl.Log.WithName("setup")
 
 	kubeConfig, err := ctrl.GetConfig()


### PR DESCRIPTION
* Interoperator  Broker: log level now can be changed from values.yaml (.values.broker.log_level)
* Interoperator: We can now change log level, log output format and stacktrace level for interoperator logging from value.yaml (values.interoperator.log_level, values.interoperator.log_output_format, values.interoperator.log_stacktrace_level) 
*  Operator_apis: We can now change log level, log output format and stacktrace level for operator_apis logging from value.yaml (values.operator_apis.log_level, values.operator_apis.log_output_format, values.operator_apis.log_stacktrace_level) 