### PR TITLE
moving quota regions credentials to secret

### DIFF
--- a/broker/core/app-config/src/index.js
+++ b/broker/core/app-config/src/index.js
@@ -81,6 +81,16 @@ if (process.env.QUOTA_PASSWORD) {
   config.quota.password = process.env.QUOTA_PASSWORD;
 }
 
+_.each(process.env, (value, key) => {
+  if(key.substring(0,7) == "REGION_"){
+      let region_info=key.split('_');
+      if(region_info.at(-1)=="USERNAME")
+        config.quota.regions[region_info.slice(1,-1).join('-').toLowerCase()]['username']=process.env[key]
+      else
+        config.quota.regions[region_info.slice(1,-1).join('-').toLowerCase()]['password']=process.env[key]
+  }
+});
+
 if(!_.isEmpty(_.get(config, 'quota.whitelist', []))) {
   // convert org names in whitelist to lowercase, for case insensitive matching
   config.quota.whitelist = _.map(config.quota.whitelist, org => {

--- a/helm-charts/interoperator/conf/settings.yaml
+++ b/helm-charts/interoperator/conf/settings.yaml
@@ -109,9 +109,19 @@ defaults: &defaults
     mtls:
       enabled: {{ .Values.broker.quota.mtls.enabled }}
       client_id: {{ .Values.broker.quota.mtls.client_id }}
-    {{- with .Values.broker.quota.regions }}
     regions:
       {{- toYaml . | nindent 6 }}
+    {{- range $k, $v := .Values.broker.quota.regions }}
+      {{ $k }}:
+    {{- range $kk, $vv := $v }}
+    {{- if and (ne $kk "username") (ne $kk "password") }}
+    {{- if eq $kk "mtls" }}
+        {{ $kk }}: {{ $vv | toYaml | nindent 10 }}
+    {{- else }}
+        {{ $kk }}: {{ $vv }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
     {{- end }}
 
 development: &development

--- a/helm-charts/interoperator/conf/settings.yaml
+++ b/helm-charts/interoperator/conf/settings.yaml
@@ -110,7 +110,6 @@ defaults: &defaults
       enabled: {{ .Values.broker.quota.mtls.enabled }}
       client_id: {{ .Values.broker.quota.mtls.client_id }}
     regions:
-      {{- toYaml . | nindent 6 }}
     {{- range $k, $v := .Values.broker.quota.regions }}
       {{ $k }}:
     {{- range $kk, $vv := $v }}

--- a/helm-charts/interoperator/templates/quota_app.yaml
+++ b/helm-charts/interoperator/templates/quota_app.yaml
@@ -86,6 +86,20 @@ spec:
               name: {{ .Release.Name }}-creds
               key: quota_password
         {{- end }}
+        {{- range $k, $v := .Values.broker.quota.regions }}
+        {{- if eq $v.mtls.enabled false }}
+        - name: {{ print "REGION_" }}{{ upper $v.name | replace "-" "_" }}{{ print "_USERNAME" }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Release.Name }}-creds
+              key: {{ print "region_" }}{{ $v.name }}{{ print "_username" }}
+        - name: {{ print "REGION_" }}{{ upper $v.name | replace "-" "_" }}{{ print "_PASSWORD" }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Release.Name }}-creds
+              key: {{ print "region_" }}{{ $v.name }}{{ print "_password" }}
+        {{- end }}
+        {{- end }}
         volumeMounts:
         {{- if not (empty .Values.broker.quota.mtls.cert_secret) }}
         - name: 'cert-secret'

--- a/helm-charts/interoperator/templates/secret.yaml
+++ b/helm-charts/interoperator/templates/secret.yaml
@@ -17,3 +17,10 @@ data:
   {{- end }}
   operator_apis_username: {{ .Values.operator_apis.username | b64enc }}
   operator_apis_password: {{ .Values.operator_apis.password | b64enc }}
+  {{- range $k, $v := .Values.broker.quota.regions }}
+  {{- range $kk, $vv := $v }}
+  {{- if or (eq $kk "username") (eq $kk "password") }}
+  {{ printf "region_%s_%s" $k $kk }}: {{ $vv | b64enc }}
+  {{- end }}
+  {{- end }}
+  {{- end }}


### PR DESCRIPTION
This is a security feature, here we are moving region based credentials to the secrets so that credentials shall not get exposed.

How we are doing it:

- Moving region details from values.yml excluding username and password to config
- Moving username and password to secrets of each region in a specific format to identify them
- Adding username and password in quota_app.yml as env so that it can be consumed