### PR TITLE
[IOP]Namespace labels

### DIFF
--- a/broker/data-access-layer/eventmesh/src/ApiServerClient.js
+++ b/broker/data-access-layer/eventmesh/src/ApiServerClient.js
@@ -369,7 +369,8 @@ class ApiServerClient {
       kind: CONST.APISERVER.NAMESPACE_OBJECT,
       apiVersion: CONST.APISERVER.NAMESPACE_API_VERSION,
       metadata: {
-        name: name
+        name: name,
+        ...!(_.isEmpty(config.apiserver.services_namespace_labels)) && {labels: _.get(config.apiserver, 'services_namespace_labels')}
       }
     };
     const client = this._getApiClient('', CONST.APISERVER.NAMESPACE_API_VERSION);

--- a/broker/data-access-layer/eventmesh/test/eventmesh.ApiServerClient.spec.js
+++ b/broker/data-access-layer/eventmesh/test/eventmesh.ApiServerClient.spec.js
@@ -1201,6 +1201,7 @@ describe('eventmesh', () => {
             expect(res.body).to.eql({});
             mocks.verify();
             config.apiserver.enable_namespaced_separation = false;
+            delete config.apiserver.services_namespace_labels;
           });
       });
     });

--- a/helm-charts/interoperator/conf/settings.yaml
+++ b/helm-charts/interoperator/conf/settings.yaml
@@ -59,6 +59,12 @@ defaults: &defaults
     getConfigInCluster: true
     isServiceDefinitionAvailableOnApiserver: true
     enable_namespaced_separation: {{ .Values.broker.enable_namespaced_separation }}
+    {{- if .Values.broker.services_namespace_labels }}
+    services_namespace_labels:
+    {{- range $k, $v := .Values.broker.services_namespace_labels }}
+      {{ $k }}: {{ $v }}
+    {{- end }}
+    {{- end }}
     services_namespace: {{ .Values.broker.services_namespace }}
     crds:
       "osb.servicefabrik.io_v1alpha1_sfserviceinstances.yaml": {{ (.Files.Get "crds/sfserviceinstance.yaml") | b64enc }}

--- a/helm-charts/interoperator/values.yaml
+++ b/helm-charts/interoperator/values.yaml
@@ -15,6 +15,12 @@ broker:
   password: secret
   log_level: info
   enable_namespaced_separation: true
+  services_namespace_labels:
+    # # Note: The labels are igonored if enable_namespaced_separation is false.
+    # app.kubernetes.io/managed-by: Interoperator
+    # # Try out Pod Security Admission in k8s v1.25
+    # pod-security.kubernetes.io/enforce: restricted
+    # pod-security.kubernetes.io/enforce-version: v1.25
   services_namespace: "services"
   allow_concurrent_operations: true
   allow_concurrent_binding_operations: true

--- a/helm-charts/interoperator/values.yaml
+++ b/helm-charts/interoperator/values.yaml
@@ -17,7 +17,7 @@ broker:
   enable_namespaced_separation: true
   services_namespace_labels:
     # # Note: The labels are igonored if enable_namespaced_separation is false.
-    # app.kubernetes.io/managed-by: Interoperator
+    app.kubernetes.io/managed-by: Interoperator
     # # Try out Pod Security Admission in k8s v1.25
     # pod-security.kubernetes.io/enforce: restricted
     # pod-security.kubernetes.io/enforce-version: v1.25


### PR DESCRIPTION
This pull request adds support for configuring custom labels on namespace created by Interoperator.
The label, `app.kubernetes.io/managed-by: Interoperator` is added as an example which is useful for identifying the namespaces manged by Interoperator.

Snippet from values.yaml,
```sh
broker: 
  enable_namespaced_separation: true
  services_namespace_labels: 
  	# Note: The labels are igonored if enable_namespaced_separation is false.
	app.kubernetes.io/managed-by: Interoperator
	# Try out Pod Security Admission in k8s v1.25
	# pod-security.kubernetes.io/warn: restricted
        # pod-security.kubernetes.io/warn-version: v1.25
```

