### PR TITLE
Update aync binding documentation

### DIFF
--- a/docs/Interoperator-Features.md
+++ b/docs/Interoperator-Features.md
@@ -96,7 +96,7 @@ If `asyncBinding` is set to `true` for the plan, the service binding operation w
 One can use the [last operation endpoint for service bindings](https://github.com/openservicebrokerapi/servicebroker/blob/v2.14/spec.md#polling-last-operation-for-service-bindings) to poll the state of the service binding operation.
 Refer [this documentation](https://github.com/openservicebrokerapi/servicebroker/blob/v2.14/spec.md#binding) to know more.
 
-Please note that `cf create-service-key` operation does not support asynchronous service binding. So `cf create-service-key` will not work with asynchronous plans. 
+Please note that cf cli version 7 or lower does not support asynchronous service binding.
 
 ## GET Endpoints for Service Instance and Service Binding
 


### PR DESCRIPTION
The `cf cli` version 8 added support for asynchronous service key creation. This pull request updates the documentation.