### PR TITLE
[IOP] Updating doc for new metrics controllers

### DIFF
--- a/docs/Interoperator-metrics.md
+++ b/docs/Interoperator-metrics.md
@@ -14,6 +14,19 @@ interoperator_cluster_service_instances | cluster | Number of service instances 
 interoperator_cluster_allocatable | cluster <br> type | Allocatable resources partitioned by cluster and resource type
 interoperator_service_bindings_state | binding_id <br> instance_id | State of the service binding.<br> 0 - succeeded <br> 1 - failed <br> 2 - in progress <br> 3 - in_queue/update/delete <br> 4 - gone
 
+From Interoperator release v0.25.1 there are 2 new controllers added to push metrics for service instance and binding calls.  
+The 2 new controllers are  
+* sfserviceinstancemetrics
+* sfservicebindingmetrics
+
+Details of new metrics from these 2 new controllers are describe below  
+
+Metric | Labels | Description
+--- | --- | ---
+interoperator_service_instances_metrics_state | instance_id <br> state <br> creation_timestamp <br> deletion_timestamp <br> service_id <br> plan_id <br> org_guid <br> space_guid <br> namespace <br> last_operation | State of the service instance.<br> 0 - succeeded <br> 1 - failed <br> 2 - in progress <br> 3 - in_queue/update/delete <br> 4 - gone
+interoperator_service_bindings_metrics_state | binding_id <br> instance_id <br> state <br> creation_timestamp <br> deletion_timestamp <br> namespace | State of the service binding.<br> 0 - succeeded <br> 1 - failed <br> 2 - in progress <br> 3 - in_queue/update/delete <br> 4 - gone
+
+
 ## Liveness and Readiness Probe
 The metrics endpoints are exposed regardless of the status of leader election. So the metrics endpoint is used as liveness and readiness probe for the pods. If the metric endpoint is not up, liveness probe will fail and kubernetes will restart the pod.
 

--- a/docs/Interoperator-metrics.md
+++ b/docs/Interoperator-metrics.md
@@ -15,11 +15,7 @@ interoperator_cluster_allocatable | cluster <br> type | Allocatable resources pa
 interoperator_service_bindings_state | binding_id <br> instance_id | State of the service binding.<br> 0 - succeeded <br> 1 - failed <br> 2 - in progress <br> 3 - in_queue/update/delete <br> 4 - gone
 
 From Interoperator release v0.25.1 there are 2 new controllers added to push metrics for service instance and binding calls.  
-The 2 new controllers are  
-* sfserviceinstancemetrics
-* sfservicebindingmetrics
-
-Details of new metrics from these 2 new controllers are describe below  
+One may view more detailed information of the instances and bindings using the following metrics.  
 
 Metric | Labels | Description
 --- | --- | ---


### PR DESCRIPTION
* This Change updates the document about new metrics added  (interoperator_service_bindings_metrics_state, interoperator_service_instances_metrics_state) by the 2 new controllers (sfserviceinstancemetrics and sfservicebindingmetrics)