### PR TITLE
Update npm version

### DIFF
--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -9,7 +9,7 @@ EXPOSE 9293 9296
 
 # you'll likely want the latest npm, regardless of node version, for speed and fixes
 # but pin this version for the best stability
-RUN npm i npm@latest -g
+RUN npm i npm@9.8.1 -g
 
 # install dependencies first, in a different location for easier app bind mounting for local development
 WORKDIR /opt/service-fabrik-broker/broker


### PR DESCRIPTION
Updating nodejs version to v9.8.1
Latest version of npm is not compatible with node js version used in Interoperator (node js version used:16.18). 
Latest version of npm: 10.0.0, Supported node version: "node": "^18.17.0 || >=20.5.0"