### PR TITLE
update Interoperator metrics doc

### DIFF
--- a/docs/Interoperator-metrics.md
+++ b/docs/Interoperator-metrics.md
@@ -19,8 +19,8 @@ One may view more detailed information of the instances and bindings using the f
 
 Metric | Labels | Description
 --- | --- | ---
-interoperator_service_instances_metrics_state | instance_id <br> state <br> creation_timestamp <br> deletion_timestamp <br> service_id <br> plan_id <br> org_guid <br> space_guid <br> namespace <br> last_operation | State of the service instance.<br> 0 - succeeded <br> 1 - failed <br> 2 - in progress <br> 3 - in_queue/update/delete <br> 4 - gone
-interoperator_service_bindings_metrics_state | binding_id <br> instance_id <br> state <br> creation_timestamp <br> deletion_timestamp <br> namespace | State of the service binding.<br> 0 - succeeded <br> 1 - failed <br> 2 - in progress <br> 3 - in_queue/update/delete <br> 4 - gone
+interoperator_service_instances_metrics_state | instance_id <br> state <br> creation_timestamp <br> deletion_timestamp <br> service_id <br> plan_id <br> organization_guid <br> space_guid <br> sf_namespace <br> last_operation | State of the service instance.<br> 0 - succeeded <br> 1 - failed <br> 2 - in progress <br> 3 - in_queue/update/delete <br> 4 - gone
+interoperator_service_bindings_metrics_state | binding_id <br> instance_id <br> state <br> creation_timestamp <br> deletion_timestamp <br> sf_namespace | State of the service binding.<br> 0 - succeeded <br> 1 - failed <br> 2 - in progress <br> 3 - in_queue/update/delete <br> 4 - gone
 
 
 ## Liveness and Readiness Probe


### PR DESCRIPTION
The Interoperator metrics doc is outdated. Update the doc to match the correct label names:
- [interoperator_service_instances_metrics_state](https://github.com/cloudfoundry/service-fabrik-broker/blob/v0.26.0/interoperator/controllers/multiclusterdeploy/sfserviceinstancemetrics/sfserviceinstancemetrics_controller.go#L45-L55)
- [interoperator_service_bindings_metrics_state](https://github.com/cloudfoundry/service-fabrik-broker/blob/v0.26.0/interoperator/controllers/multiclusterdeploy/sfservicebindingmetrics/sfservicebindingmetrics_controller.go#L45-L54)